### PR TITLE
Fix employer map display and user view

### DIFF
--- a/assets/map-picker.js
+++ b/assets/map-picker.js
@@ -26,6 +26,27 @@
       attribution: '© OpenStreetMap contributors'
     }).addTo(map);
 
+    // Ensure proper rendering when initialized in hidden containers
+    // 1) Invalidate size right after init
+    setTimeout(() => { try { map.invalidateSize(false); } catch (e) {} }, 0);
+    // 2) Invalidate on window resize
+    window.addEventListener('resize', () => {
+      try { map.invalidateSize(false); } catch (e) {}
+    });
+    // 3) Observe visibility changes of the map container and refresh when it becomes visible
+    try {
+      const io = new IntersectionObserver((entries) => {
+        entries.forEach(entry => {
+          if (entry.isIntersecting) {
+            setTimeout(() => { try { map.invalidateSize(false); } catch (e) {} }, 50);
+          }
+        });
+      }, { threshold: 0.1 });
+      io.observe(mapEl);
+    } catch (e) {
+      // IntersectionObserver not available; skip
+    }
+
     let marker = null;
 
     function setMarker(lat, lng) {

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -58,6 +58,7 @@ body {
 }
 
 .container { width: 100%; max-width: 1100px; margin: 0 auto; padding: 0 20px; }
+.leaflet-container { background: transparent !important; }
 .header { position: sticky; top: 0; z-index: 20; background: rgba(11, 15, 28, 0.75); backdrop-filter: saturate(120%) blur(6px); border-bottom: 1px solid var(--border); transition: all 0.3s ease; }
 [data-theme="light"] .header { background: rgba(248, 250, 252, 0.75); }
 


### PR DESCRIPTION
Fixes gray Leaflet map display on employer page by ensuring proper rendering when visible and making its background transparent.

Leaflet maps often fail to render correctly (showing gray tiles) when initialized within hidden elements (like tabs) or when their container's size changes. This PR addresses this by forcing the map to re-evaluate its size when it becomes visible and on window resize, and by ensuring the map container itself doesn't have an opaque background.

---
<a href="https://cursor.com/background-agent?bcId=bc-384ab980-7584-4b92-b891-f3477785eb24">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-384ab980-7584-4b92-b891-f3477785eb24">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

